### PR TITLE
FixGitHub

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,11 +6,7 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
-on:
-  push:
-    branches: [ FIPS-8557 ]
-  pull_request:
-    branches: [ FIPS-8557 ]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -20,10 +16,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       eclipse-release: ['2019-03', '2019-06', '2019-09', '2019-12', '2020-03', '2020-06', '2020-09', '2020-12', '2021-03', '2021-06', '2021-09', '2021-12', '2022-03']
+       eclipse-release: ['2020-03', '2020-06', '2020-09', '2020-12', '2021-03', '2021-06', '2021-09', '2021-12', '2022-03', '2022-06']
 
     env:
-       integration-test-release: '2019-03'
+       integration-test-release: '2020-03'
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 8

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-build</artifactId>
-        <version>2.7.0</version>
+        <version>3.0.0-SNAPSHOT</version>
     </extension>
 </extensions>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -19,7 +19,7 @@
         <maven-bundle-plugin.version>5.1.6</maven-bundle-plugin.version>
         <flatten-maven-plugin.version>1.2.7</flatten-maven-plugin.version>
         <!-- java and compiler options -->
-        <java.version>1.8</java.version>
+        <java.version>8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>

--- a/settings.xml
+++ b/settings.xml
@@ -109,6 +109,13 @@
             <layout>p2</layout>
             <mirrorOfLayouts>p2</mirrorOfLayouts>
         </mirror>
+        <mirror>
+            <id>faktorzehn-2022-06</id>
+            <mirrorOf>https://update.faktorzehn.org/p2repositories/2022-06</mirrorOf>
+            <url>http://download.eclipse.org/releases/2022-06</url>
+            <layout>p2</layout>
+            <mirrorOfLayouts>p2</mirrorOfLayouts>
+        </mirror>
         
         <!-- Babel -->
         <mirror>


### PR DESCRIPTION
- FIPS-8557/FIPS-8558 :: #17 : Include org.faktorips.build.config in faktorips.base
- FIPS-8557/FIPS-8577 :: #13 : Use a public parent pom
- FIPS-8557/FIPS-8593 :: #9 : Use Maven dependecies instead of custom update-site
- Issue #12 create a github action for the build.
- FIPS-8557/FIPS-8695 :: Issue #12 : Enable matrix job builds, Issue #9 : Use a common base target for thirdparty
- FIPS-8557/FIPS-8696 :: Update README.MD
- FIPS-8557/FIPS-8715 :: Update Github actions
- FIPS-8557/FIPS-8697 :: Issue #21 : Prepare conversion to plain maven projects
- FIPS-8557/FIPS-8729 :: Issue #21 : Convert org.faktorips.valuetypes.joda
- FIPS-8557/FIPS-8735 :: Issue #21 : Convert org.faktorips.runtime
- FIPS-6474/FIPS-8650 :: add @since without VersionProvider
- FIPS-8720/FIPS-8753 :: Use Xtend instead of old Xpand
- FIPS-8096/FIPS-8754 :: Disable category changes for policy attributes in product-only subclasses
- FIPS-8740/FIPS-8755 :: Allow configuration of marker for missing mandatory value
- FIPS-8095/FIPS-8608 :: Generate constant for default value of a policy attribute
- FIPS-8095/FIPS-8609 :: Return default value constant for model objects
- FIPS-7548/FIPS-8620 :: added interface INamedDatatype
- FIPS-5440/FIPS-8655 :: Allow collections as return value of datatypes' getAllValuesMethod
- FIPS-7548/FIPS-8763 :: Cherry pick FIPS-5440 : Allow collections as return value of datatypes' getAllValuesMethod
- FIPS-7548/FIPS-8621 :: initialize datatypes
- FIPS-7198/FIPS-8627 :: Make enum contents actually serializable
- FIPS-8768/FIPS-8769 :: Fix template XML
- FIPS-8768/FIPS-8771 :: Javadoc for abstractions
- FIPS-8768/FIPS-8769 :: Fix template XML
- FIPS-7548/FIPS-8622 :: use EnumDisplaySettings for NamedDataTypes
- FIPS-7548/FIPS-8623 :: added to description
- FIPS-6872/FIPS-8764 :: Unify generation of multi value default values
- FIPS-7548/FIPS-8773 :: Fix validation for enum data types
- FIPS-451/FIPS-8611 :: Add IDeprecation
- FIPS-451/FIPS-8612 :: Add deprecated ui
- FIPS-8557/FIPS-8744 :: Use imported packages instead of required and reexported
- FIPS-4708/FIPS-8628 :: added Currency as default datatype
- FIPS-5440/FIPS-8778 :: Find enum value by name from all values if not getValueByNameMethod is set
- FIPS-451/FIPS-8613 :: Show deprecation in Model Description View
- FIPS-451/FIPS-8788 :: Add deprecation elements to schemas
- FIPS-451/FIPS-8788 :: Add deprecation elements to schemas
- FIPS-451/FIPS-8789 :: Mark icons of deprecated elements
- FIPS-451/FIPS-8614 :: Show Deprecation in NewProductCmptWizard
- FIPS-8790/FIPS-8791 :: Escape quotes in MANIFEST.MF
- FIPS-451/FIPS-8615 :: Generate @Deprecated
- FIPS-451/FIPS-8793 :: Validate deprecated base types
- FIPS-451/FIPS-8617 :: Allow deprecation to be queried in the IpsModel
- FIPS-8662/FIPS-8783 :: Treat blank strings as null
- FIPS-5278/FIPS-8629 :: Configure discriminator column length
- FIPS-8401/FIPS-8652 :: move to unique base package
- FIPS-8401/FIPS-8784 :: added doc to .ipsproject
- FIPS-5278/FIPS-8630 :: Validate Discriminator Value Length
- FIPS-8231/FIPS-8648 :: Merge XML-Adapter
- FIPS-8708/FIPS-8782 :: Copy DefaultGenericAttributeValidationConfiguration.properties with "_en"
- FIPS-8159/FIPS-8633 :: Add Jakarta Persistence / EclipseLink 3
- FIPS-8772/FIPS-8781 :: Simplify DatatypeDefinitions Configuration
- FIPS-8159/FIPS-8635 :: Set persistence provider dependencies in archetype and when adding the IpsNature
- FIPS-8794/FIPS-8802 :: remove only same instance
- FIPS-8807/FIPS-8808 :: Allow setting the varied base in InMemoryRuntimeRepositiory
- FIPS-8314/FIPS-8809 :: Add qualified property to IpsAssociation annotation
- FIPS-8314/FIPS-8810 :: Write qualified attribute in @IpsAssociation
- FIPS-8314/FIPS-8811 :: Add isQualified to IpsModel PolicyAssociation
- FIPS-5698/FIPS-8816 :: Always use ValueSet as return type for unified value set methods
- FIPS-8741/FIPS-8821 :: Add IpsMatchers#hasMarker
- FIPS-5698/FIPS-8815 :: Allow enums as subsets of ranges when using unified value sets
- FIPS-8667/FIPS-8669 :: Target for Eclipse 2022-06
- FIPS-8667/FIPS-8835 :: Add target 2022-06 to targets module
- FIPS-8836/FIPS-8837 :: Restore backwards compatibility of PolicyAttribute#getDefaultValue
- FIPS-8840/FIPS-8858 :: Allow access to org.faktorips.devtools.core.internal.productrelease for org.faktorips.productrelease.*
- FIPS-8838/FIPS-8839 :: Fixed migration dialog text and some other mistakes
- IPSPV-651/IPSPV-655 :: Refactor property pages for easier reuse
- FIPS-8859/FIPS-8860 :: Fixed changing slashes when migrating in Windows
- FIPS-8867/FIPS-8868 :: Remove unnecessary blanks in comments
- FIPS-8876/FIPS-8877 :: Message.Builder should add, not replace object properties
- FIPS-8871/FIPS-8872 :: Increase serialVersionUID for generated enum classes
- FIPS-8878/FIPS-8883 :: Improve Message Matcher Messages
- FIPS-8557/FIPS-8777 :: Convert org.faktorips.runtime.groovy to plain Maven project
- FIPS-8867/FIPS-8868 :: Remove unnecessary blanks in comments
- rename codequality-config
- FIPS-8889/FIPS-8909 :: Revert FIPS-6934: Fix javadoc and annotations for setters of derived attributes
- FIPS-8889/FIPS-8909 :: Revert FIPS-6934: Add computed attributes to builder
- FIPS-8911/FIPS-8912 :: Change labels for policy attribute checkboxes
- FIPS-8796/FIPS-8910 :: Fortify Mojo against different versions in different projects and honor toolchains
- FIPS-8917/FIPS-8918 :: Persist all datatype attributes in .ipsproject
- FIPS-8675/FIPS-8822 :: Set XML Schema for .ipsproject
- FIPS-8906/FIPS-8908 :: Bei Kombination aus BOTH und UNIFIED generiert FIPS nicht alle notwendigen Methoden
- FIPS-8926/FIPS-8927 :: Remove outdated commons-collections dependency
- FIPS-8863/FIPS-8864 :: use local xsd's if not online
- FIPS-7298/FIPS-8861 :: Add JUnit 5 Adapters
- FIPS-8557/FIPS-8929 :: rename org.faktorips.runtime to faktorips-runtime
- FIPS-8557/FIPS-8888 :: testsupport umstellen
- FIPS-8557/FIPS-8884 :: faktorips-util umstellen
- FIPS-8557/FIPS-8886 :: dtfl umstellen
- FIPS-8557/FIPS-8885 :: faktorips-fl umstellen
- FIPS-8867/FIPS-8931 :: removed even more blanks
- FIPS-8936/FIPS-8938 :: Explicitly handle null objects in range structures
- FIPS-8937/FIPS-8942 :: Migrate MANIFEST.MF even in src/main/resources
- FIPS-8944/FIPS-8945 :: Count Jar open/close calls
- FIPS-8891/FIPS-8893 :: Make some XML Attributes optional
- FIPS-8891/FIPS-8934 :: Dont write boolean = false in XMLs if it is the default value
- FIPS-8826/FIPS-8828 :: Update launch configs for Eclipse 2022-06 RC 1
- FIPS-8953/FIPS-8954 :: Add version to invalid manifests
- FIPS-8974/FIPS-8976 :: Don't generate blank lines at the start of Javadoc
- FIPS-8895/FIPS-8979 :: Add NullObject-aware comparators
- FIPS-8557/FIPS-8887 :: Split abstraction in plain-Java and Eclipse
- Update version to 22.6.1
- FIPS-8989/FIPS-8990 :: Dividing Decimal by Decimal.NULL should return Decimal.NULL
- FIPS-8997/FIPS-8998 :: Add JAXB dependency in Java 11 profile and ignore SuppressWarnings changes
- FIPS-8956/FIPS-9002 :: Include ProductRelease in .ipsproject XSD
- Update version to 22.12.0
- FIPS-9009/FIPS-9010 :: make build java 17 compatible
- FIPS-8557/FIPS-8975 :: Use flatten-maven-plugin
- FIPS-8557/FIPS-9026 :: use flatten plugin in runtime/client and add license
- FIPS-9003/FIPS-9005 :: Fix access to upper case enum attributes and table columns
- FIPS-9029/FIPS-9048 :: Unwrap EclipseFile to IFile in adapter factory
- FIPS-9044/FIPS-9049 :: Fix single value range without step
- FIPS-9015/FIPS-9034 :: Add XSD to archetype .ipsproject templates
- FIPS-9052/FIPS-9053 :: Add delta computation option to ignore moved objects
- FIPS-9037/FIPS-9038 :: Add dependencies to ensure build order
- FIPS-9037/FIPS-9038 :: call gpg from non-pom directory
- FIPS-8557/FIPS-9024 :: make build java 17 compatible
- FIPS-9088/FIPS-9092 :: add referencedIpsProject to ipsproperties xsd
- FIPS-9042/FIPS-9076 :: Empty String allowed as default value for StringLengthValueSet
- FIPS-8932/FIPS-9095 :: show confirmation dialog before deleting an attribute
- FIPS-8557/FIPS-9093 :: Fixes
- FIPS-6964/FIPS-9101 :: Add Select/Deselect All Button to Migration Wizard
- FIPS-8598/FIPS-9102 :: enable containsNullCheckbox for multilingual attributes
- FIPS-8471/FIPS-9106 :: Print message instead of NPE for missing datatype definition
- FIPS-8598/FIPS-9109 :: Show Error when violation mandatory field for multilingual attributes
- FIPS-7476/FIPS-9114 :: Fix: no literal column in enum contents
- FIPS-7874/FIPS-9085 :: Replace deprecated Eclipse API
- FIPS-7874/FIPS-9123 :: Replace SubProgressMonitor
- FIPS-8949/FIPS-9097 :: Show tables, formulas and rules in description view + add filter menu
- FIPS-9130/FIPS-9131 :: new min version eclipse-2020-03
- FIPS-9130/FIPS-9138 :: update maven plugin
- FIPS-9100/FIPS-9129 :: Fix: Uncontrolled appending of description strings in the type-selection wizard
- FIPS-9110/FIPS-9139 :: Fix Tycho 3 build
- FIPS-7874/FIPS-9124 :: Replace deprecated contentassist api
- FIPS-9042/FIPS-9151 :: fix null/blank string as default value
- FIPS-8562/FIPS-9146 :: fix product component type associations
- FIPS-8562/FIPS-9146 :: fix product component type associations, part 2
- FIPS-9110/FIPS-9166 :: Clean up files overlooked by merge
- FIPS-8946/FIPS-8947 :: New formatter/cleanUp settings
- FIPS-9180/FIPS-9182 :: fix faktorips base build
- FIPS-9185/FIPS-9186 :: change url to w3.org xsd to https
- IPSPV-663/IPSPV-666 :: Clean up IPS for PV use
- FIPS-7188/FIPS-9158 :: Fix enum content export
- FIPS-9130/FIPS-9192 :: Set target platform to baseline 2020-03
- FIPS-9196/FIPS-9198 :: Use portable String representation of ToC path
- FIPS-5556/FIPS-9140 :: Set correct cardinalities when creating new links
- FIPS-9045/FIPS-9082 :: Restructure to better align with maven conventions and introduce BOMs to allow other projects access to project and dependency versions
- FIPS-9042/FIPS-9191 :: Validierung bei Produktattributen <null> equals ''
- Fix Fips Build
- Fix GitHub actions
