### PR TITLE
Declare some missing pom dependencies

### DIFF
--- a/devtools/eclipse/features/pom.xml
+++ b/devtools/eclipse/features/pom.xml
@@ -42,5 +42,18 @@
             <groupId>org.faktorips</groupId>
             <artifactId>faktorips-dtfl-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.faktorips</groupId>
+            <artifactId>faktorips-fl</artifactId>
+        </dependency>    
+        <dependency>
+            <groupId>org.faktorips</groupId>
+            <artifactId>faktorips-abstraction</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.faktorips</groupId>
+            <artifactId>faktorips-abstraction-plainjava</artifactId>
+        </dependency>
+        
     </dependencies>
 </project>


### PR DESCRIPTION
- faktorips-fl is referenced in feature but not declared as pom dependency
- faktorips-abstraction  is required but not included
- faktorips-abstraction-plainjava is required but not included

While working on 
- https://github.com/eclipse-tycho/tycho/issues/1555

i noticed that the features build just get some pom reactor dependencies pulled in indirectly. With Tycho 4.0 this will not work anymore and they should explicitly included.

As it seems the set of dependencies largely overlap with the bundles, one might even think about to move the dependencies to the `faktorips.base/devtools/eclipse/pom.xml` instead to prevent duplication efforts.