### PR TITLE
Exclude problematic dependency from requirementsHistoryDetectionRange

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -99,6 +99,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-report-plugin</artifactId>
                     <version>${maven-plugin-report-plugin.version}</version>
+                    <configuration>
+                    	<!-- Version 21 has a bad dependency and therefore fails the ececution of this goal -->
+                    	<requirementsHistoryDetectionRange>[22,)</requirementsHistoryDetectionRange>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Currently the maven-plugin-report-plugin fails the build as it tries to load an non existing parent pom.

This now exclude the version from the check and simply starts at a higher version.

Fix https://github.com/faktorips/faktorips.base/issues/71